### PR TITLE
Change broken refs in l1atbd

### DIFF
--- a/L1_ATBD/dataformat.tex
+++ b/L1_ATBD/dataformat.tex
@@ -49,9 +49,9 @@ coordinates using WGS84 reference ellipsoid.
     URLS                  & URLs to more detailed information of scan. 
                             \begin{itemize}
                              \item URL-spectra: link to scan Leve1B-data (see Table~\ref{table:dataformat})
-                             \item URL-ptz: link to scan PTZ-data (see Table~\ref{table:ptzdataformat})
+                             \item URL-ptz: link to scan PTZ-data (see~\cite{iodd})
                              \item URL-apriori-\textit{specices} link to available scan apriori data 
-                              (see Table~\ref{table:aprioridataformat}),
+                              (see~\cite{iodd}),
                               where \textit{species} can be any of: 'BrO', 'Cl2O2', 'CO', 'HCl', 'HO2', 'NO2',
                               'OCS', 'C2H2', 'ClO', 'H2CO', 'HCN', 'HOBr', 'NO', 'OH', 'C2H6', 'ClONO2', 'H2O2',
                               'HCOOH', 'HOCl', 'O2', 'SF6', 'CH3Cl', 'ClOOCl', 'H2O', 'HF', 'N2', 'O3', 'SO2',

--- a/L1_ATBD/references.bib
+++ b/L1_ATBD/references.bib
@@ -582,3 +582,11 @@ DOI = {10.5194/acp-15-5099-2015}
  year    = {2005},
 }
 
+@Techreport{iodd,
+  AUTHOR =        {B. Rydberg and P. Eriksson and J. Petersson and A. Skyman
+                  and D. Murtagh},
+  TITLE =         {Input/Output Data Definition Document: Level2 processor},
+  INSTITUTION =   {Department of Space, Earth and Environment,
+                   Chalmers University of Technology},
+  YEAR  =         {2016},
+}


### PR DESCRIPTION
Two tables were referenced in the L1 ATBD that did not exist. This changes to referencing the IODD instead.